### PR TITLE
Refactor migrations

### DIFF
--- a/app/Game.php
+++ b/app/Game.php
@@ -16,13 +16,13 @@ class Game extends Model
         'name',
         'description',
         'category',
-        'pending',
-        'premium',
+        'is_pending',
+        'is_premium',
     ];
 
     protected $casts = [
-        'pending'   =>  'boolean',
-        'premium'   =>  'boolean',
+        'is_pending'   =>  'boolean',
+        'is_premium'   =>  'boolean',
     ];
 
     public function category(): BelongsTo

--- a/app/Http/Controllers/Administration/GameController.php
+++ b/app/Http/Controllers/Administration/GameController.php
@@ -62,8 +62,8 @@ class GameController extends Controller
     {
         $game = new Game();
         $game->fill($request->all('name', 'url', 'description', 'category_id'));
-        $game->pending = $request->has('pending');
-        $game->premium = $request->has('premium');
+        $game->is_pending = $request->has('is_pending');
+        $game->is_premium = $request->has('is_premium');
         $game->uuid = \Str::uuid();
         $game->save();
 
@@ -107,8 +107,8 @@ class GameController extends Controller
     public function update(CreateGameRequest $request, Game $game): RedirectResponse
     {
         $game->fill($request->all('name', 'url', 'description', 'category_id'));
-        $game->pending = $request->has('pending');
-        $game->premium = $request->has('premium');
+        $game->is_pending = $request->has('is_pending');
+        $game->is_premium = $request->has('is_premium');
         $game->save();
 
         return redirect()

--- a/app/Http/Controllers/Administration/HomeController.php
+++ b/app/Http/Controllers/Administration/HomeController.php
@@ -22,8 +22,8 @@ class HomeController extends Controller
             'votesIn' => 0,
             'votesOut' => 0,
             'users' => User::all()->count(),
-            'gamesPendingReview' => $games->where('pending', '=', false)->count(),
-            'goldMembership' => $games->where('premium', '=', true)->count(),
+            'gamesPendingReview' => $games->where('is_pending', '=', false)->count(),
+            'goldMembership' => $games->where('is_premium', '=', true)->count(),
         ];
 
         return view('administration.index', compact('gamesReleasedChartData', 'gamesReleasedChartLabels', 'stats'));

--- a/app/User.php
+++ b/app/User.php
@@ -38,7 +38,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
-        'is_admin' => 'bool',
+        'is_admin' => 'boolean',
     ];
 
     public function isAdmin(): bool

--- a/app/User.php
+++ b/app/User.php
@@ -38,10 +38,11 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'is_admin' => 'bool',
     ];
 
     public function isAdmin(): bool
     {
-        return $this->isAdmin === 1;
+        return $this->is_admin === true;
     }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateUsersTable extends Migration
 {
@@ -11,15 +11,15 @@ class CreateUsersTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->boolean('isAdmin')->default(0);
+            $table->boolean('is_admin')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });
@@ -30,7 +30,7 @@ class CreateUsersTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('users');
     }

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreatePasswordResetsTable extends Migration
 {
@@ -11,9 +11,9 @@ class CreatePasswordResetsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('password_resets', function (Blueprint $table) {
+        Schema::create('password_resets', static function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
@@ -25,7 +25,7 @@ class CreatePasswordResetsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('password_resets');
     }

--- a/database/migrations/2019_06_13_171104_create_table_categories.php
+++ b/database/migrations/2019_06_13_171104_create_table_categories.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTableCategories extends Migration
 {
@@ -11,12 +11,12 @@ class CreateTableCategories extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('categories', function (Blueprint $table) {
+        Schema::create('categories', static function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string("name");
-            $table->string("slug");
+            $table->string('name');
+            $table->string('slug')->unique();
             $table->timestamps();
         });
     }
@@ -26,7 +26,7 @@ class CreateTableCategories extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('categories');
     }

--- a/database/migrations/2019_06_13_171335_create_table_games.php
+++ b/database/migrations/2019_06_13_171335_create_table_games.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTableGames extends Migration
 {
@@ -11,25 +11,25 @@ class CreateTableGames extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('games', function (Blueprint $table) {
+        Schema::create('games', static function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->uuid("uuid");
-            $table->string("url");
-            $table->string("name");
-            $table->text("description");
-            $table->bigInteger("category_id")->unsigned();
-            $table->string("slug");
-            $table->boolean("pending")->default(false);
-            $table->boolean("premium")->default(false);
-            $table->bigInteger("votes_in")->default(0);
-            $table->bigInteger("votes_out")->default(0);
+            $table->uuid('uuid');
+            $table->bigInteger('category_id')->unsigned();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->string('url');
+            $table->text('description');
+            $table->boolean('is_pending')->default(false);
+            $table->boolean('is_premium')->default(false);
+            $table->bigInteger('votes_in')->default(0);
+            $table->bigInteger('votes_out')->default(0);
             $table->timestamps();
 
-            $table->foreign("category_id")
-                ->references("id")
-                ->on("categories");
+            $table->foreign('category_id')
+                ->references('id')
+                ->on('categories');
         });
     }
 
@@ -38,7 +38,7 @@ class CreateTableGames extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('games');
     }

--- a/database/migrations/2019_06_14_160133_create_votes.php
+++ b/database/migrations/2019_06_14_160133_create_votes.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateVotes extends Migration
 {
@@ -11,12 +11,12 @@ class CreateVotes extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('votes', function (Blueprint $table) {
+        Schema::create('votes', static function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->ipAddress("ip");
-            $table->tinyInteger("type");
+            $table->ipAddress('ip');
+            $table->tinyInteger('type');
             $table->timestamps();
         });
     }
@@ -26,7 +26,7 @@ class CreateVotes extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('votes');
     }

--- a/resources/views/administration/game/edit.blade.php
+++ b/resources/views/administration/game/edit.blade.php
@@ -23,8 +23,8 @@
             {!! \Form::text('url', 'Url') !!}
             {!! \Form::textarea('description', 'Description') !!}
             {!! \Form::select('category', 'Category', $categories, $game->category->id) !!}
-            {!! \Form::checkbox('pending', 'Visible', 1, $game->pending) !!}
-            {!! \Form::checkbox('premium', 'Is Premium', 1, $game->premium) !!}
+            {!! \Form::checkbox('is_pending', 'Is Visible', 1, $game->is_pending) !!}
+            {!! \Form::checkbox('is_premium', 'Is Premium', 1, $game->is_premium) !!}
             {!! \Form::submit('Update Game') !!}
             {!! \Form::close() !!}
         </div>

--- a/resources/views/administration/game/show.blade.php
+++ b/resources/views/administration/game/show.blade.php
@@ -55,7 +55,7 @@
                 </tr>
                 <tr>
                     <td>Votes Out</td>
-                    <td>{{ number_format($game->votes_in) }}</td>
+                    <td>{{ number_format($game->votes_out) }}</td>
                 </tr>
                 </tbody>
             </table>

--- a/resources/views/administration/game/show.blade.php
+++ b/resources/views/administration/game/show.blade.php
@@ -43,11 +43,11 @@
                 </tr>
                 <tr>
                     <td>Pending</td>
-                    <td>{{ $game->pending === false ? 'Review Needed' : 'Active' }}</td>
+                    <td>{{ $game->is_pending === false ? 'Review Needed' : 'Active' }}</td>
                 </tr>
                 <tr>
                     <td>Premium</td>
-                    <td>{{ $game->premium === true ? 'Premium' : 'Standard' }}</td>
+                    <td>{{ $game->is_premium === true ? 'Premium' : 'Standard' }}</td>
                 </tr>
                 <tr>
                     <td>Votes In</td>


### PR DESCRIPTION
- Declare migration method return types for good practice
- Use single quotes everywhere for consistency
- Reorder imports where needed for consistency
- Change user.isAdmin to user.is_admin for column field naming consistency. Also fixed the User->isAdmin(), and added it to cast to bool
- Use static closures for good practice, since we don't need to access $this-> within these (good practice)
- Make slugs unique (which I assume they should be, like if accessible through the URL). This also creates an index on the column, speeding up fetching it from the database due to the index
- Reorder games table columns:
  - IDs first
  - Relational IDs next
  - Slug (also some form of identifier) next, also make it unique
  - Data fields next
  - Booleans/flags next, prefixed with 'is_' for consistency
  - Votes and timestamps after